### PR TITLE
Aggiornamento ParseOptionalEnumPipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mo-id/nest-toolbelt",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mo-id/nest-toolbelt",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "devDependencies": {
         "@mo-id/typescript-toolbelt": "^0.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mo-id/nest-toolbelt",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mo-id/nest-toolbelt",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "devDependencies": {
         "@mo-id/typescript-toolbelt": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mo-id/nest-toolbelt",
   "repository": "git://github.com/mo-id/moid-nest-toolbelt.git",
   "author": "moid",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mo-id/nest-toolbelt",
   "repository": "git://github.com/mo-id/moid-nest-toolbelt.git",
   "author": "moid",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/utils/parseOptionalEnum.pipe.ts
+++ b/src/utils/parseOptionalEnum.pipe.ts
@@ -1,3 +1,4 @@
+import { Nullable } from "@mo-id/typescript-toolbelt";
 import {
   Injectable,
   ParseEnumPipe,
@@ -6,14 +7,13 @@ import {
 } from "@nestjs/common";
 
 @Injectable()
-export class ParseOptionalEnumPipe<T = any> implements PipeTransform<T> {
-  private enumType: T;
+export class ParseOptionalEnumPipe<EnumType = any> implements PipeTransform {
+  constructor(private enumType: EnumType) {}
 
-  constructor(enumType: T) {
-    this.enumType = enumType;
-  }
-
-  async transform(value: any, metadata: ArgumentMetadata) {
+  async transform(
+    value: any,
+    metadata: ArgumentMetadata
+  ): Promise<Nullable<EnumType>> {
     if (value === undefined || value === null) {
       return Promise.resolve(null);
     }

--- a/src/utils/parseOptionalEnum.pipe.ts
+++ b/src/utils/parseOptionalEnum.pipe.ts
@@ -1,8 +1,19 @@
-import { Injectable, ParseEnumPipe, ArgumentMetadata } from "@nestjs/common";
+import {
+  Injectable,
+  ParseEnumPipe,
+  ArgumentMetadata,
+  PipeTransform,
+} from "@nestjs/common";
 
 @Injectable()
-export class ParseOptionalEnumPipe extends ParseEnumPipe {
-  transform(value: any, metadata: ArgumentMetadata) {
+export class ParseOptionalEnumPipe<T = any> implements PipeTransform<T> {
+  private enumType: T;
+
+  constructor(enumType: T) {
+    this.enumType = enumType;
+  }
+
+  async transform(value: any, metadata: ArgumentMetadata) {
     if (value === undefined || value === null) {
       return Promise.resolve(null);
     }
@@ -11,6 +22,8 @@ export class ParseOptionalEnumPipe extends ParseEnumPipe {
       return Promise.resolve(null);
     }
 
-    return super.transform(value, metadata);
+    const pipe = new ParseEnumPipe(this.enumType);
+    const parsedValue = await pipe.transform(value, metadata);
+    return parsedValue;
   }
 }


### PR DESCRIPTION
Questa PR aggiorna la pipe `ParseOptionalEnumPipe` per rimuovere gli errori di compilazione nell'installazione della libreria `nest-toolbelt`